### PR TITLE
feat(wishlist): desktop trash icon, scroll-to-hide toolbar, FAB viewp…

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -41,3 +41,18 @@
   flex-direction: column;
   min-height: 0;
 }
+
+@media (pointer: coarse) {
+  .toolbar {
+    overflow: hidden;
+    max-height: 250px;
+    transition:
+      max-height 0.3s ease,
+      opacity 0.2s ease;
+  }
+
+  .toolbarHidden {
+    max-height: 0;
+    opacity: 0;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Header } from '@/components/Header/Header';
 import { SearchBar } from '@/components/SearchBar/SearchBar';
@@ -19,6 +19,8 @@ export default function App() {
   const { songs, allSongs, isLoading, sortField, setSortField } = useSongs();
   const featureFlags = useFeatureFlags();
   const [isWishlistOpen, setIsWishlistOpen] = useState(false);
+  const [isToolbarHidden, setIsToolbarHidden] = useState(false);
+  const handleScrollHide = useCallback((hidden: boolean) => setIsToolbarHidden(hidden), []);
   const { wishlistedIds, toggleSong, removeSong, clearAll, fabPosition, saveFabPosition } =
     useWishlist();
 
@@ -43,24 +45,26 @@ export default function App() {
 
       <main id="main-content" className={styles.main}>
         <div className={styles.content}>
-          <SearchBar
-            query={search.query}
-            onChange={search.setQuery}
-            resultCount={displaySongs.length}
-            totalCount={filteredSongs.length}
-            isSearching={search.isSearching}
-          />
-          <FilterChips
-            activeMain={filter.main}
-            activeDecade={filter.decade}
-            activeCountry={filter.country}
-            availableCountries={availableCountries}
-            availableDecades={availableDecades}
-            featureFlags={featureFlags}
-            onMainChange={setMainFilter}
-            onDecadeChange={setDecadeFilter}
-            onCountryChange={setCountryFilter}
-          />
+          <div className={`${styles.toolbar}${isToolbarHidden ? ` ${styles.toolbarHidden}` : ''}`}>
+            <SearchBar
+              query={search.query}
+              onChange={search.setQuery}
+              resultCount={displaySongs.length}
+              totalCount={filteredSongs.length}
+              isSearching={search.isSearching}
+            />
+            <FilterChips
+              activeMain={filter.main}
+              activeDecade={filter.decade}
+              activeCountry={filter.country}
+              availableCountries={availableCountries}
+              availableDecades={availableDecades}
+              featureFlags={featureFlags}
+              onMainChange={setMainFilter}
+              onDecadeChange={setDecadeFilter}
+              onCountryChange={setCountryFilter}
+            />
+          </div>
           <SongList
             songs={displaySongs}
             isLoading={isLoading}
@@ -68,6 +72,8 @@ export default function App() {
             onSortChange={setSortField}
             wishlistedIds={featureFlags.wishlist ? wishlistedIds : undefined}
             onToggleWishlist={featureFlags.wishlist ? toggleSong : undefined}
+            isToolbarHidden={isToolbarHidden}
+            onScrollHide={handleScrollHide}
           />
         </div>
       </main>

--- a/src/components/SongList/SongList.module.css
+++ b/src/components/SongList/SongList.module.css
@@ -122,3 +122,21 @@
     padding: 0.25rem 0.625rem;
   }
 }
+
+@media (pointer: coarse) {
+  .sortBar {
+    overflow: hidden;
+    max-height: 60px;
+    transition:
+      max-height 0.3s ease,
+      padding 0.3s ease,
+      opacity 0.2s ease;
+  }
+
+  .sortBarHidden {
+    max-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    opacity: 0;
+  }
+}

--- a/src/components/SongList/SongList.tsx
+++ b/src/components/SongList/SongList.tsx
@@ -14,6 +14,8 @@ interface SongListProps {
   onSortChange: (field: SortField) => void;
   wishlistedIds?: string[];
   onToggleWishlist?: (id: string) => void;
+  isToolbarHidden?: boolean;
+  onScrollHide?: (hidden: boolean) => void;
 }
 
 export function SongList({
@@ -23,9 +25,13 @@ export function SongList({
   onSortChange,
   wishlistedIds,
   onToggleWishlist,
+  isToolbarHidden,
+  onScrollHide,
 }: SongListProps) {
   const { t } = useTranslation();
   const parentRef = useRef<HTMLDivElement>(null);
+  const lastScrollTopRef = useRef(0);
+  const scrollDirectionRef = useRef<'up' | 'down' | null>(null);
 
   const [showBackToTop, setShowBackToTop] = useState(false);
 
@@ -38,10 +44,29 @@ export function SongList({
   useEffect(() => {
     const el = parentRef.current;
     if (!el) return;
-    const handleScroll = () => setShowBackToTop(el.scrollTop > 300);
+    const handleScroll = () => {
+      const scrollTop = el.scrollTop;
+      setShowBackToTop(scrollTop > 300);
+
+      const diff = scrollTop - lastScrollTopRef.current;
+      lastScrollTopRef.current = scrollTop;
+
+      if (scrollTop <= 5) {
+        if (scrollDirectionRef.current !== 'up') {
+          scrollDirectionRef.current = 'up';
+          onScrollHide?.(false);
+        }
+      } else if (diff > 10 && scrollDirectionRef.current !== 'down') {
+        scrollDirectionRef.current = 'down';
+        onScrollHide?.(true);
+      } else if (diff < -10 && scrollDirectionRef.current !== 'up') {
+        scrollDirectionRef.current = 'up';
+        onScrollHide?.(false);
+      }
+    };
     el.addEventListener('scroll', handleScroll, { passive: true });
     return () => el.removeEventListener('scroll', handleScroll);
-  }, []);
+  }, [onScrollHide]);
 
   const scrollToTop = () => {
     parentRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
@@ -79,7 +104,11 @@ export function SongList({
 
   return (
     <div className={styles.container}>
-      <div className={styles.sortBar} role="toolbar" aria-label={t('songList.sortLabel')}>
+      <div
+        className={`${styles.sortBar}${isToolbarHidden ? ` ${styles.sortBarHidden}` : ''}`}
+        role="toolbar"
+        aria-label={t('songList.sortLabel')}
+      >
         <span className={styles.sortLabel}>{t('songList.sortLabel')}:</span>
         <button
           className={`${styles.sortButton} ${sortField === 'artist' ? styles.sortActive : ''}`}

--- a/src/components/Wishlist/WishlistFAB.tsx
+++ b/src/components/Wishlist/WishlistFAB.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './WishlistFAB.module.css';
 
@@ -57,6 +57,21 @@ export function WishlistFAB({ count, position, onOpen, onPositionChange }: Wishl
     },
     [clamp],
   );
+
+  useEffect(() => {
+    const handleResize = () => {
+      const clamped = clamp(currentPositionRef.current.x, currentPositionRef.current.y);
+      if (
+        clamped.x !== currentPositionRef.current.x ||
+        clamped.y !== currentPositionRef.current.y
+      ) {
+        currentPositionRef.current = clamped;
+        onPositionChange(clamped.x, clamped.y);
+      }
+    };
+    window.addEventListener('resize', handleResize, { passive: true });
+    return () => window.removeEventListener('resize', handleResize);
+  }, [clamp, onPositionChange]);
 
   const handlePointerUp = useCallback(() => {
     if (isDraggingRef.current) {

--- a/src/components/Wishlist/WishlistItem.module.css
+++ b/src/components/Wishlist/WishlistItem.module.css
@@ -80,6 +80,25 @@
   font-size: clamp(0.8125rem, 3vw, 0.9375rem);
 }
 
+@media (pointer: fine) {
+  .wrapper {
+    display: flex;
+    flex-direction: row-reverse;
+    overflow: visible;
+  }
+
+  .deleteZone {
+    position: static;
+    width: 48px;
+    flex-shrink: 0;
+  }
+
+  .content {
+    flex: 1;
+    min-width: 0;
+  }
+}
+
 @media (max-width: 400px) {
   .songInfo {
     flex-direction: column;

--- a/src/components/Wishlist/WishlistItem.tsx
+++ b/src/components/Wishlist/WishlistItem.tsx
@@ -13,6 +13,10 @@ interface WishlistItemProps {
 
 const REVEAL_THRESHOLD = 48;
 const MAX_REVEAL = 96;
+const IS_MOUSE_DEVICE =
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(pointer: fine)').matches;
 
 export function WishlistItem({ song, onDelete, isForceClose, onReveal, onTap }: WishlistItemProps) {
   const { t } = useTranslation();
@@ -30,6 +34,7 @@ export function WishlistItem({ song, onDelete, isForceClose, onReveal, onTap }: 
   }
 
   const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (IS_MOUSE_DEVICE) return;
     startXRef.current = e.clientX;
     startYRef.current = e.clientY;
     swipeActiveRef.current = false;
@@ -111,11 +116,11 @@ export function WishlistItem({ song, onDelete, isForceClose, onReveal, onTap }: 
 
   return (
     <div className={styles.wrapper} role="listitem">
-      <div className={styles.deleteZone} aria-hidden="true">
+      <div className={styles.deleteZone} aria-hidden={IS_MOUSE_DEVICE ? undefined : 'true'}>
         <button
           className={styles.deleteButton}
           onClick={handleDeleteClick}
-          tabIndex={isRevealed ? 0 : -1}
+          tabIndex={IS_MOUSE_DEVICE || isRevealed ? 0 : -1}
           type="button"
           aria-label={t('wishlist.deleteItem')}
         >

--- a/src/components/Wishlist/WishlistPanel.tsx
+++ b/src/components/Wishlist/WishlistPanel.tsx
@@ -24,9 +24,12 @@ export function WishlistPanel({
   const [isClosing, setIsClosing] = useState(false);
   const [revealedId, setRevealedId] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const prevIsOpenRef = useRef(isOpen);
+  const prevIsOpen = prevIsOpenRef.current;
+  prevIsOpenRef.current = isOpen;
 
   if (isOpen && !isMounted) setIsMounted(true);
-  if (isOpen && isClosing) setIsClosing(false);
+  if (!prevIsOpen && isOpen && isClosing) setIsClosing(false); // re-opened while closing animation played
   if (!isOpen && isMounted && !isClosing) setIsClosing(true);
 
   const handleClose = useCallback(() => {


### PR DESCRIPTION
…ort clamp on resize

- WishlistItem: always-visible trash button on pointer:fine devices (no swipe needed)
- SongList/App: hide search bar, filter chips, and sort bar on scroll down (mobile only); reveal on scroll up
- WishlistFAB: clamp position back into viewport on window resize (orientation change)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>