### PR TITLE
feat(pipeline): auto-trigger Process Song List workflow after scan upload

### DIFF
--- a/pipeline/remote-scan/aktualizuj-liste.bat
+++ b/pipeline/remote-scan/aktualizuj-liste.bat
@@ -44,10 +44,32 @@ if %ERRORLEVEL% neq 0 (
     echo  Aktualizacja nie powiodla sie.
     echo  Szczegoly bledu znajdziesz w pliku: scan-log.txt
     echo  (w tym samym folderze co ten skrypt)
-) else (
     echo.
-    echo  Gotowe!
+    pause
+    exit /b 1
 )
 
+echo.
+echo  Lista plikow wyslana. Uruchamiam workflow Process Song List...
+echo.
+
+powershell -ExecutionPolicy Bypass -Command ^
+  "$token = (Get-Content '%~dp0scan-config.json' -Raw | ConvertFrom-Json).githubToken; " ^
+  "$repo = (Get-Content '%~dp0scan-config.json' -Raw | ConvertFrom-Json).githubRepo; " ^
+  "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; " ^
+  "$headers = @{ 'Authorization' = \"Bearer $token\"; 'Accept' = 'application/vnd.github.v3+json'; 'User-Agent' = 'ZyletaKaraoke/1.0' }; " ^
+  "$body = '{\"ref\":\"master\",\"inputs\":{\"force_refresh\":\"false\"}}'; " ^
+  "try { " ^
+  "  Invoke-RestMethod -Uri \"https://api.github.com/repos/$repo/actions/workflows/update-songs.yml/dispatches\" -Headers $headers -Method Post -Body $body -ContentType 'application/json'; " ^
+  "  Write-Host '  Workflow uruchomiony!' -ForegroundColor Green; " ^
+  "  Write-Host '  Postep: https://github.com/$repo/actions' -ForegroundColor Gray; " ^
+  "} catch { " ^
+  "  Write-Host '  UWAGA: Nie udalo sie uruchomic workflow automatycznie.' -ForegroundColor Yellow; " ^
+  "  Write-Host '  Sprawdz czy token ma uprawnienie Actions: Read and write.' -ForegroundColor Yellow; " ^
+  "  Write-Host \"  $($_.Exception.Message)\" -ForegroundColor Red; " ^
+  "}"
+
+echo.
+echo  Gotowe!
 echo.
 pause


### PR DESCRIPTION
## Summary

- `aktualizuj-liste.bat` po udanym uploadzenie `raw-filelist.json` teraz automatycznie wywołuje `workflow_dispatch` na `update-songs.yml` z `force_refresh=false`
- Dotychczas workflow trzeba było odpalać ręcznie z poziomu GitHub
- Logika dispatch jest analogiczna do istniejącej w `wymus-pelna-aktualizacje.bat` (tam `force_refresh=true`)

## Wymaganie

Token w `scan-config.json` musi mieć uprawnienie **Actions: Read and write** — jeśli go nie ma, skrypt wyświetli ostrzeżenie zamiast się wywrócić.

🤖 Generated with [Claude Code](https://claude.com/claude-code)