### PR TITLE
perf(pipeline): switch AI enricher to Haiku, reduce max_tokens

### DIFF
--- a/pipeline/ai-enricher.ts
+++ b/pipeline/ai-enricher.ts
@@ -182,8 +182,8 @@ async function callClaude(systemPrompt: string, userMessage: string): Promise<st
       'anthropic-version': '2023-06-01',
     },
     body: JSON.stringify({
-      model: 'claude-sonnet-4-5-20250929',
-      max_tokens: 8192,
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 2048,
       system: systemPrompt,
       messages: [{ role: 'user', content: userMessage }],
     }),


### PR DESCRIPTION
## Summary
- Switch `claude-sonnet-4-5-20250929` → `claude-haiku-4-5-20251001` (~3.75× cost reduction)
- Reduce `max_tokens` from 8192 → 2048 (realistic batch output is ~600 tokens for 30 songs; 2048 gives comfortable 3× margin)

## Rationale
The AI enrichment task (artist/title normalization, year/country/language lookup) has a narrow, well-defined output schema and operates on well-known music domain data. This is a Tier 1 task — Haiku is sufficient.

## Test plan
- [ ] Merge after currently running Process Song List workflow completes
- [ ] Trigger a manual run of Process Song List to verify Haiku produces valid enrichment output