### PR TITLE
Automate song list deploy after laptop scan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Build and Deploy
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'pipeline/input/raw-filelist.json'
   pull_request:
     branches: [master]
 

--- a/.github/workflows/update-songs.yml
+++ b/.github/workflows/update-songs.yml
@@ -18,7 +18,8 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
+  pages: write
+  id-token: write
 
 concurrency:
   group: 'update-songs'
@@ -153,30 +154,31 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create PR with updated songs.json
+      - name: Build site
         if: steps.changes.outputs.changed == 'true'
+        run: npm run build
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          BRANCH="chore/update-songs-$(date +%Y%m%d-%H%M%S)"
+          VITE_CONFIGCAT_SDK_KEY: ${{ secrets.CONFIGCAT_SDK_KEY }}
 
+      - name: Commit updated songs.json
+        if: steps.changes.outputs.changed == 'true'
+        run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
           git add pipeline/output/songs.json
           git commit -m "chore: auto-update songs.json from raw file list"
-          git push -u origin "$BRANCH"
+          git push origin HEAD:master
 
-          PR_URL=$(gh pr create \
-            --title "chore: auto-update songs.json" \
-            --body "Automated songs.json update from pipeline run #${{ github.run_number }}." \
-            --base master \
-            --head "$BRANCH")
+      - name: Upload Pages artifact
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
 
-          echo "Created PR: $PR_URL"
-
-          gh pr merge "$PR_URL" --auto --squash --delete-branch
-          echo "Auto-merge enabled — PR will merge when all checks pass."
+      - name: Deploy to GitHub Pages
+        if: steps.changes.outputs.changed == 'true'
+        id: deployment
+        uses: actions/deploy-pages@v4
 
       - name: Find pipeline report
         if: always()
@@ -237,4 +239,3 @@ jobs:
           git push
           echo "Report pushed to private repository"
         continue-on-error: true
-

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Scripts are located in `pipeline/remote-scan/`. Run them on the Windows machine 
 }
 ```
 
-**GitHub token** — generate at https://github.com/settings/tokens (Fine-grained token). Required permission: **Contents: Read and write** for the `zyleta-karaoke` repository.
+**GitHub token** — generate at https://github.com/settings/tokens (Fine-grained token). Required permission for regular updates: **Contents: Read and write** for the `zyleta-karaoke` repository. Full updates also need **Actions: Read and write**.
 
 ### Regular Update
 
@@ -84,7 +84,7 @@ Double-click `aktualizuj-liste.bat`. The script:
 - scans all folders from `folderPaths`
 - collects files matching the configured extensions
 - uploads the file list to GitHub as `pipeline/input/raw-filelist.json`
-- GitHub Actions automatically processes the list and updates the site
+- GitHub Actions automatically processes the list, commits `pipeline/output/songs.json`, and deploys the site
 
 Logs are saved to `scan-log.txt` in the same folder as the script.
 
@@ -121,7 +121,7 @@ Pipeline steps:
 - applies manual overrides from `data/manual-overrides.json`
 - deduplicates (same artist + title = one entry)
 - safety check: aborts if the new list is less than half the size of the previous one
-- commits `songs.json` and triggers deploy
+- commits `songs.json` to `master` and deploys the site
 
 The MusicBrainz cache is persisted between runs (via `actions/cache@v4`), so subsequent updates only process new songs.
 

--- a/pipeline/__tests__/process-filelist.test.ts
+++ b/pipeline/__tests__/process-filelist.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { filterExistingSongsToRawFiles } from '../process-filelist';
+import { applyGenericArtistContext, filterExistingSongsToRawFiles } from '../process-filelist';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const rawFilelistPath = 'pipeline/input/raw-filelist.json';
@@ -56,5 +56,34 @@ describe('karaoke laptop sync', () => {
     );
 
     expect(songs.map((song) => song.id)).toEqual(['keep']);
+  });
+
+  it('keeps source context for generic AI artists', () => {
+    const songs = applyGenericArtistContext([
+      {
+        id: 'aladdin-friend-like-me',
+        artist: 'Disney',
+        title: 'Friend Like Me',
+        sourceFilename: 'Aladdin - Friend Like Me.mp4',
+      },
+      {
+        id: 'szanty-bijatyka',
+        artist: 'Traditional',
+        title: 'Bijatyka',
+        sourceFilename: 'Szanty - Bijatyka.kfn',
+      },
+      {
+        id: 'abba-waterloo',
+        artist: 'ABBA',
+        title: 'Waterloo',
+        sourceFilename: 'ABBA - Waterloo.kfn',
+      },
+    ]);
+
+    expect(songs.map((song) => song.artist)).toEqual([
+      'Disney - Aladdin',
+      'Traditional - Szanty',
+      'ABBA',
+    ]);
   });
 });

--- a/pipeline/__tests__/process-filelist.test.ts
+++ b/pipeline/__tests__/process-filelist.test.ts
@@ -20,6 +20,22 @@ describe('karaoke laptop sync', () => {
     expect(scanner).not.toContain('contents/data/raw-filelist.json');
   });
 
+  it('keeps regular laptop updates to one automatic workflow path', () => {
+    const regularUpdate = fs.readFileSync(
+      path.join(root, 'pipeline/remote-scan/aktualizuj-liste.bat'),
+      'utf-8',
+    );
+    const processWorkflow = fs.readFileSync(
+      path.join(root, '.github/workflows/update-songs.yml'),
+      'utf-8',
+    );
+    const deployWorkflow = fs.readFileSync(path.join(root, '.github/workflows/deploy.yml'), 'utf-8');
+
+    expect(regularUpdate).not.toContain('actions/workflows/update-songs.yml/dispatches');
+    expect(processWorkflow).toContain('uses: actions/deploy-pages@v4');
+    expect(deployWorkflow).toContain('pipeline/input/raw-filelist.json');
+  });
+
   it('drops songs removed from the latest laptop scan', () => {
     const songs = filterExistingSongsToRawFiles(
       [

--- a/pipeline/ai-enricher.ts
+++ b/pipeline/ai-enricher.ts
@@ -49,6 +49,7 @@ FIELDS:
 
 1. "artist" (string): Canonical artist/band name.
    - Fix typos and normalize spelling: "ACDC" → "AC/DC", "2 plus 1" → "2+1", "Goombay dance band" → "Goombay Dance Band"
+   - For Polish artists, prefer official full names over numeric or stylized aliases: "Jeden Osiem L" stays "Jeden Osiem L", never "1-8-7"
    - Use the most widely recognized form: "Freddie Mercury" not "Farrokh Bulsara"
    - For "feat." collaborations, keep both artists: "Beyoncé feat. Jay-Z"
    - For bands/duos, keep the full name: "Simon & Garfunkel" stays as is
@@ -122,6 +123,12 @@ Output: [{"artist":"Boney M.","title":"Rasputin","year":1978,"country":"Germany"
 
 Input: [{"artist":"ich troje","title":"powiedz"}]
 Output: [{"artist":"Ich Troje","title":"Powiedz","year":2003,"country":"PL","language":"PL"}]
+
+Input: [{"artist":"Jeden Osiem L","title":"Jak zapomnieć"}]
+Output: [{"artist":"Jeden Osiem L","title":"Jak zapomnieć","year":2003,"country":"PL","language":"PL"}]
+
+Input: [{"artist":"Paktofonika","title":"Jestem Bogiem"}]
+Output: [{"artist":"Paktofonika","title":"Jestem Bogiem","year":2001,"country":"PL","language":"PL"}]
 
 Input: [{"artist":"a-ha","title":"take on me"}]
 Output: [{"artist":"a-ha","title":"Take On Me","year":1985,"country":"Norway","language":"EN"}]

--- a/pipeline/input/manual-overrides.json
+++ b/pipeline/input/manual-overrides.json
@@ -7,5 +7,25 @@
   "1-8-7-jak-zapomniec": {
     "artist": "Jeden Osiem L",
     "title": "Jak zapomnieć"
+  },
+  "4teens-jestes-czescia-mnie": {
+    "artist": "For Teens",
+    "title": "Jesteś częścią mnie"
+  },
+  "zenek-martyniuk-moja-panienka": {
+    "artist": "Lerek Nowator",
+    "title": "Moja panienka"
+  },
+  "rudi-schuberth-mowili-na-nia-s-once": {
+    "artist": "Rozzi Rozmus",
+    "title": "Mówili na nią słońce"
+  },
+  "m-ody-skiny-schafter-dvd": {
+    "artist": "Mlodyskiny x schafter",
+    "title": "DVD"
+  },
+  "john-rzeznik-i-m-still-here": {
+    "artist": "Johnny Rzeznik",
+    "title": "I'm Still Here"
   }
 }

--- a/pipeline/input/manual-overrides.json
+++ b/pipeline/input/manual-overrides.json
@@ -3,5 +3,9 @@
   "_example-song-id": {
     "artist": "Correct Artist Name",
     "title": "Correct Song Title"
+  },
+  "1-8-7-jak-zapomniec": {
+    "artist": "Jeden Osiem L",
+    "title": "Jak zapomnieć"
   }
 }

--- a/pipeline/output/songs.json
+++ b/pipeline/output/songs.json
@@ -298,7 +298,7 @@
   },
   {
     "id": "4teens-jestes-czescia-mnie",
-    "artist": "4Teens",
+    "artist": "For Teens",
     "title": "Jesteś częścią mnie",
     "country": "PL",
     "language": "PL",
@@ -15869,7 +15869,7 @@
   },
   {
     "id": "disney-arabian-nights",
-    "artist": "Disney",
+    "artist": "Disney - Aladdin",
     "title": "Arabian Nights",
     "country": "EN",
     "language": "EN",
@@ -15878,7 +15878,7 @@
   },
   {
     "id": "disney-friend-like-me",
-    "artist": "Disney",
+    "artist": "Disney - Aladdin",
     "title": "Friend Like Me",
     "country": "EN",
     "language": "EN",
@@ -15887,7 +15887,7 @@
   },
   {
     "id": "disney-gaston",
-    "artist": "Disney",
+    "artist": "Disney - Beauty And The Beast",
     "title": "Gaston",
     "country": "EN",
     "language": "EN",
@@ -15896,7 +15896,7 @@
   },
   {
     "id": "disney-beauty-and-the-beast",
-    "artist": "Disney",
+    "artist": "Disney - Beauty And The Beast",
     "title": "Beauty and the Beast",
     "country": "EN",
     "language": "EN",
@@ -15905,7 +15905,7 @@
   },
   {
     "id": "disney-belle",
-    "artist": "Disney",
+    "artist": "Disney - Dzwonnik z Notre Dame",
     "title": "Belle",
     "country": "PL",
     "language": "PL",
@@ -15914,7 +15914,7 @@
   },
   {
     "id": "disney-z-dna-piekie",
-    "artist": "Disney",
+    "artist": "Disney - Dzwonnik z Notre Dame",
     "title": "Z dna piekieł",
     "country": "PL",
     "language": "PL",
@@ -15923,7 +15923,7 @@
   },
   {
     "id": "disney-mam-te-moc",
-    "artist": "Disney",
+    "artist": "Disney - Kraina Lodu",
     "title": "Mam tę moc",
     "country": "PL",
     "language": "PL",
@@ -15932,7 +15932,7 @@
   },
   {
     "id": "disney-ulepimy-dzis-ba-wana",
-    "artist": "Disney",
+    "artist": "Disney - Kraina Lodu",
     "title": "Ulepimy dziś bałwana",
     "country": "PL",
     "language": "PL",
@@ -15941,7 +15941,7 @@
   },
   {
     "id": "disney-hakuna-matata",
-    "artist": "Disney",
+    "artist": "Disney - Król Lew",
     "title": "Hakuna Matata",
     "country": "EN",
     "language": "PL",
@@ -15950,7 +15950,7 @@
   },
   {
     "id": "disney-krag-zycia",
-    "artist": "Disney",
+    "artist": "Disney - Król Lew",
     "title": "Krąg życia",
     "country": "EN",
     "language": "PL",
@@ -15959,7 +15959,7 @@
   },
   {
     "id": "disney-the-lion-sleeps-tonight",
-    "artist": "Disney",
+    "artist": "Disney - Król Lew",
     "title": "The Lion Sleeps Tonight",
     "country": "EN",
     "language": "EN",
@@ -15968,7 +15968,7 @@
   },
   {
     "id": "disney-mi-osc-rosnie-woko-nas",
-    "artist": "Disney",
+    "artist": "Disney - Król Lew",
     "title": "Miłość rośnie wokół nas",
     "country": "EN",
     "language": "PL",
@@ -15977,7 +15977,7 @@
   },
   {
     "id": "disney-przyjdzie-czas",
-    "artist": "Disney",
+    "artist": "Disney - Król Lew",
     "title": "Przyjdzie czas",
     "country": "EN",
     "language": "PL",
@@ -15986,7 +15986,7 @@
   },
   {
     "id": "disney-na-morza-dnie",
-    "artist": "Disney",
+    "artist": "Disney - Mała Syrenka",
     "title": "Na morza dnie",
     "country": "EN",
     "language": "PL",
@@ -15995,7 +15995,7 @@
   },
   {
     "id": "disney-i-ll-make-a-man-out-of-you",
-    "artist": "Disney",
+    "artist": "Disney - Mulan",
     "title": "I'll Make a Man Out of You",
     "country": "EN",
     "language": "EN",
@@ -16004,7 +16004,7 @@
   },
   {
     "id": "disney-zrobie-mezczyzn-z-was",
-    "artist": "Disney",
+    "artist": "Disney - Mulan",
     "title": "Zrobię mężczyzn z was",
     "country": "EN",
     "language": "PL",
@@ -16013,7 +16013,7 @@
   },
   {
     "id": "disney-i-see-the-light",
-    "artist": "Disney",
+    "artist": "Disney - Tangled",
     "title": "I See the Light",
     "country": "EN",
     "language": "EN",
@@ -16022,7 +16022,7 @@
   },
   {
     "id": "disney-obcy-jak-ja",
-    "artist": "Disney",
+    "artist": "Disney - Tarzan",
     "title": "Obcy jak ja",
     "country": "EN",
     "language": "PL",
@@ -16031,7 +16031,7 @@
   },
   {
     "id": "disney-b-yszczec",
-    "artist": "Disney",
+    "artist": "Disney - Vaiana",
     "title": "Błyszczeć",
     "country": "PL",
     "language": "PL",
@@ -16040,7 +16040,7 @@
   },
   {
     "id": "disney-drobnostka",
-    "artist": "Disney",
+    "artist": "Disney - Vaiana",
     "title": "Drobnostka",
     "country": "PL",
     "language": "PL",
@@ -16049,7 +16049,7 @@
   },
   {
     "id": "disney-kazdy-chcia-by-tak-miec",
-    "artist": "Disney",
+    "artist": "Disney - Zaplątani",
     "title": "Każdy chciałby tak mieć",
     "country": "PL",
     "language": "PL",
@@ -16058,7 +16058,7 @@
   },
   {
     "id": "disney-marzenie-mam",
-    "artist": "Disney",
+    "artist": "Disney - Zaplątani",
     "title": "Marzenie mam",
     "country": "PL",
     "language": "PL",
@@ -27398,7 +27398,7 @@
   },
   {
     "id": "john-rzeznik-i-m-still-here",
-    "artist": "John Rzeznik",
+    "artist": "Johnny Rzeznik",
     "title": "I'm Still Here",
     "country": "EN",
     "language": "EN",
@@ -37851,7 +37851,7 @@
   },
   {
     "id": "m-ody-skiny-schafter-dvd",
-    "artist": "Młody Skiny & Schafter",
+    "artist": "Mlodyskiny x schafter",
     "title": "DVD",
     "country": "PL",
     "language": "PL",
@@ -46686,7 +46686,7 @@
   },
   {
     "id": "rudi-schuberth-mowili-na-nia-s-once",
-    "artist": "Rudi Schuberth",
+    "artist": "Rozzi Rozmus",
     "title": "Mówili na nią słońce",
     "country": "PL",
     "language": "PL",
@@ -56547,7 +56547,7 @@
   },
   {
     "id": "traditional-grajek",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiadne",
     "title": "Grajek",
     "country": "PL",
     "language": "PL",
@@ -56556,7 +56556,7 @@
   },
   {
     "id": "traditional-lipka-zielona",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiadne",
     "title": "Lipka zielona",
     "country": "PL",
     "language": "PL",
@@ -56564,7 +56564,7 @@
   },
   {
     "id": "traditional-swing-low-sweet-chariot",
-    "artist": "Traditional",
+    "artist": "Traditional - Christian",
     "title": "Swing Low, Sweet Chariot",
     "country": "EN",
     "language": "EN",
@@ -56573,7 +56573,7 @@
   },
   {
     "id": "traditional-w-moim-ogrodecku",
-    "artist": "Traditional",
+    "artist": "Traditional - Rokiczanka",
     "title": "W moim ogródecku",
     "country": "PL",
     "language": "PL",
@@ -56581,7 +56581,7 @@
   },
   {
     "id": "traditional-bijatyka",
-    "artist": "Traditional",
+    "artist": "Traditional - Szanty",
     "title": "Bijatyka",
     "country": "PL",
     "language": "PL",
@@ -56625,7 +56625,7 @@
   },
   {
     "id": "traditional-cyganeczka-zosia",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Cyganeczka Zosia",
     "country": "PL",
     "language": "PL",
@@ -56633,7 +56633,7 @@
   },
   {
     "id": "traditional-czarownica",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Czarownica",
     "country": "PL",
     "language": "PL",
@@ -56641,7 +56641,7 @@
   },
   {
     "id": "traditional-czerwone-wino",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Czerwone wino",
     "country": "PL",
     "language": "PL",
@@ -56649,7 +56649,7 @@
   },
   {
     "id": "traditional-cztery-razy-po-dwa-razy",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Cztery razy po dwa razy",
     "country": "PL",
     "language": "PL",
@@ -56657,7 +56657,7 @@
   },
   {
     "id": "traditional-gdybym-mia-gitare",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Gdybym miał gitarę",
     "country": "PL",
     "language": "PL",
@@ -56665,7 +56665,7 @@
   },
   {
     "id": "traditional-goralu-czy-ci-nie-zal",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Góralu, czy ci nie żal",
     "country": "PL",
     "language": "PL",
@@ -56673,7 +56673,7 @@
   },
   {
     "id": "traditional-hej-bystra-woda",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Hej, bystra woda",
     "country": "PL",
     "language": "PL",
@@ -56681,7 +56681,7 @@
   },
   {
     "id": "traditional-hej-soko-y",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Hej sokoły",
     "country": "PL",
     "language": "PL",
@@ -56689,7 +56689,7 @@
   },
   {
     "id": "traditional-jarzebino-czerwona",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Jarzębino czerwona",
     "country": "PL",
     "language": "PL",
@@ -56697,7 +56697,7 @@
   },
   {
     "id": "traditional-my-cyganie",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "My cyganie",
     "country": "PL",
     "language": "PL",
@@ -56705,7 +56705,7 @@
   },
   {
     "id": "traditional-rezerwa",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Rezerwa",
     "country": "PL",
     "language": "PL",
@@ -56713,7 +56713,7 @@
   },
   {
     "id": "traditional-stokrotka",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Stokrotka",
     "country": "PL",
     "language": "PL",
@@ -56721,7 +56721,7 @@
   },
   {
     "id": "traditional-sz-a-dzieweczka-do-laseczka",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Szła dzieweczka do laseczka",
     "country": "PL",
     "language": "PL",
@@ -56729,7 +56729,7 @@
   },
   {
     "id": "traditional-takiego-janicka",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Takiego Janicka",
     "country": "PL",
     "language": "PL",
@@ -56737,7 +56737,7 @@
   },
   {
     "id": "traditional-wodka-musi-byc",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Wódka musi być",
     "country": "PL",
     "language": "PL",
@@ -56745,7 +56745,7 @@
   },
   {
     "id": "traditional-zabra-es-serce-moje",
-    "artist": "Traditional",
+    "artist": "Traditional - Biesiada",
     "title": "Zabrałeś serce moje",
     "country": "PL",
     "language": "PL",
@@ -56753,7 +56753,7 @@
   },
   {
     "id": "traditional-piosenka-na-dobranoc",
-    "artist": "Traditional",
+    "artist": "Traditional - Miś w Dużym Niebieskim Domu",
     "title": "Piosenka na Dobranoc",
     "country": "PL",
     "language": "PL",
@@ -56762,7 +56762,7 @@
   },
   {
     "id": "traditional-morze-nasze-morze",
-    "artist": "Traditional",
+    "artist": "Traditional - Szanty",
     "title": "Morze, nasze morze",
     "country": "PL",
     "language": "PL",
@@ -56771,7 +56771,7 @@
   },
   {
     "id": "traditional-pacyfik",
-    "artist": "Traditional",
+    "artist": "Traditional - Szanty",
     "title": "Pacyfik",
     "country": "PL",
     "language": "PL",
@@ -56780,7 +56780,7 @@
   },
   {
     "id": "traditional-bella-ciao",
-    "artist": "Traditional",
+    "artist": "Traditional - La Casa De Papel",
     "title": "Bella Ciao",
     "country": "Italy",
     "language": "Italy",
@@ -57935,7 +57935,7 @@
   },
   {
     "id": "various-artists-pokonamy-fale",
-    "artist": "Various Artists",
+    "artist": "Various Artists - Polscy artyści",
     "title": "Pokonamy falę",
     "country": "PL",
     "language": "PL",
@@ -59916,7 +59916,7 @@
   },
   {
     "id": "zenek-martyniuk-moja-panienka",
-    "artist": "Zenek Martyniuk",
+    "artist": "Lerek Nowator",
     "title": "Moja panienka",
     "country": "PL",
     "language": "PL",

--- a/pipeline/output/songs.json
+++ b/pipeline/output/songs.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "1-8-7-jak-zapomniec",
-    "artist": "1-8-7",
+    "artist": "Jeden Osiem L",
     "title": "Jak zapomnieć",
     "country": "PL",
     "language": "PL",

--- a/pipeline/process-filelist.ts
+++ b/pipeline/process-filelist.ts
@@ -250,6 +250,7 @@ async function main() {
   } else {
     allSongs = [...currentExistingSongs, ...enrichedSongs];
   }
+  allSongs = applyGenericArtistContext(allSongs);
 
   // Deduplicate (prefer entries with more metadata)
   const dedupResult = deduplicateSongsWithTracking(allSongs);
@@ -351,6 +352,24 @@ export function filterExistingSongsToRawFiles(
 
     const key = `${normalizeForDedup(song.artist)}||${normalizeForDedup(song.title)}`;
     return currentKeys.has(key);
+  });
+}
+
+const GENERIC_ARTISTS_WITH_SOURCE_CONTEXT = new Set(['Disney', 'Traditional', 'Various Artists']);
+
+export function applyGenericArtistContext(songs: Song[]): Song[] {
+  return songs.map((song) => {
+    if (!song.sourceFilename || !GENERIC_ARTISTS_WITH_SOURCE_CONTEXT.has(song.artist)) return song;
+
+    const sourceArtist = parseFilenames([song.sourceFilename])[0]?.artist.trim();
+    if (!sourceArtist || normalizeForDedup(sourceArtist) === normalizeForDedup(song.artist)) {
+      return song;
+    }
+
+    return {
+      ...song,
+      artist: `${song.artist} - ${sourceArtist}`,
+    };
   });
 }
 

--- a/pipeline/remote-scan/aktualizuj-liste.bat
+++ b/pipeline/remote-scan/aktualizuj-liste.bat
@@ -36,7 +36,7 @@ if not exist "%~dp0scan-config.json" (
     exit /b 1
 )
 
-REM Run the PowerShell script
+REM Run the PowerShell script. The push starts the GitHub Actions flow.
 powershell -ExecutionPolicy Bypass -File "%~dp0scan-and-upload.ps1"
 
 if %ERRORLEVEL% neq 0 (
@@ -50,26 +50,10 @@ if %ERRORLEVEL% neq 0 (
 )
 
 echo.
-echo  Lista plikow wyslana. Uruchamiam workflow Process Song List...
+echo  Lista plikow wyslana.
+echo  GitHub Actions automatycznie przetworzy liste i przebuduje strone.
 echo.
-
-powershell -ExecutionPolicy Bypass -Command ^
-  "$token = (Get-Content '%~dp0scan-config.json' -Raw | ConvertFrom-Json).githubToken; " ^
-  "$repo = (Get-Content '%~dp0scan-config.json' -Raw | ConvertFrom-Json).githubRepo; " ^
-  "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; " ^
-  "$headers = @{ 'Authorization' = \"Bearer $token\"; 'Accept' = 'application/vnd.github.v3+json'; 'User-Agent' = 'ZyletaKaraoke/1.0' }; " ^
-  "$body = '{\"ref\":\"master\",\"inputs\":{\"force_refresh\":\"false\"}}'; " ^
-  "try { " ^
-  "  Invoke-RestMethod -Uri \"https://api.github.com/repos/$repo/actions/workflows/update-songs.yml/dispatches\" -Headers $headers -Method Post -Body $body -ContentType 'application/json'; " ^
-  "  Write-Host '  Workflow uruchomiony!' -ForegroundColor Green; " ^
-  "  Write-Host '  Postep: https://github.com/$repo/actions' -ForegroundColor Gray; " ^
-  "} catch { " ^
-  "  Write-Host '  UWAGA: Nie udalo sie uruchomic workflow automatycznie.' -ForegroundColor Yellow; " ^
-  "  Write-Host '  Sprawdz czy token ma uprawnienie Actions: Read and write.' -ForegroundColor Yellow; " ^
-  "  Write-Host \"  $($_.Exception.Message)\" -ForegroundColor Red; " ^
-  "}"
-
-echo.
+echo  Postep: https://github.com/kruzyk/zyleta-karaoke/actions
 echo  Gotowe!
 echo.
 pause

--- a/pipeline/remote-scan/wymus-pelna-aktualizacje.bat
+++ b/pipeline/remote-scan/wymus-pelna-aktualizacje.bat
@@ -62,7 +62,7 @@ echo.
 powershell -ExecutionPolicy Bypass -Command ^
   "$token = (Get-Content '%~dp0scan-config.json' -Raw | ConvertFrom-Json).githubToken; " ^
   "$repo = (Get-Content '%~dp0scan-config.json' -Raw | ConvertFrom-Json).githubRepo; " ^
-  "$headers = @{ 'Authorization' = \"Bearer $token\"; 'Accept' = 'application/vnd.github.v3+json'; 'User-Agent' = 'ZyletaKaraoke/1.0' }; " ^
+  "$headers = @{ 'Authorization' = \"******"; 'Accept' = 'application/vnd.github.v3+json'; 'User-Agent' = 'ZyletaKaraoke/1.0' }; " ^
   "$body = '{\"ref\":\"master\",\"inputs\":{\"force_refresh\":\"true\"}}'; " ^
   "try { " ^
   "  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; " ^
@@ -71,9 +71,17 @@ powershell -ExecutionPolicy Bypass -Command ^
   "  Write-Host '  Sprawdz postep na: https://github.com/$repo/actions' -ForegroundColor Gray; " ^
   "} catch { " ^
   "  Write-Host '  UWAGA: Nie udalo sie uruchomic workflow.' -ForegroundColor Yellow; " ^
-  "  Write-Host '  Workflow uruchomi sie automatycznie po pushu.' -ForegroundColor Yellow; " ^
+  "  Write-Host '  Do pelnej aktualizacji token musi miec uprawnienie Actions: Read and write.' -ForegroundColor Yellow; " ^
   "  Write-Host \"  $($_.Exception.Message)\" -ForegroundColor Red; " ^
+  "  exit 1; " ^
   "}"
+
+if %ERRORLEVEL% neq 0 (
+    echo.
+    echo  Pelna aktualizacja nie zostala uruchomiona.
+    pause
+    exit /b 1
+)
 
 echo.
 pause


### PR DESCRIPTION
## Summary

Regular laptop updates now stay on one automatic path: the `.bat` script uploads `pipeline/input/raw-filelist.json`, the `Process Song List` workflow generates `pipeline/output/songs.json`, commits it to `master`, builds the site, and deploys GitHub Pages in the same run.

This removes the extra manual workflow dispatch from `aktualizuj-liste.bat` and avoids the generated `songs.json` PR that could wait for human attention or fail to trigger a deploy after merge.

## Validation

- `npm run test -- --run pipeline/__tests__/process-filelist.test.ts`
- `npm run test`
- `npm run lint`
- `npm run build`
