### PR TITLE
Fix generated song update auto-merge flow

### DIFF
--- a/.github/workflows/update-songs.yml
+++ b/.github/workflows/update-songs.yml
@@ -17,9 +17,7 @@ on:
           - 'true'
 
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: 'update-songs'
@@ -154,31 +152,42 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build site
+      - name: Create or update generated songs PR
         if: steps.changes.outputs.changed == 'true'
-        run: npm run build
         env:
-          VITE_CONFIGCAT_SDK_KEY: ${{ secrets.CONFIGCAT_SDK_KEY }}
-
-      - name: Commit updated songs.json
-        if: steps.changes.outputs.changed == 'true'
+          GH_TOKEN: ${{ secrets.SONG_UPDATE_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::Missing SONG_UPDATE_TOKEN secret"
+            exit 1
+          fi
+
+          BRANCH="automation/update-songs"
+
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch origin "$BRANCH:refs/remotes/origin/$BRANCH" || true
+          git switch -C "$BRANCH"
+
+          git config user.name "zyleta-karaoke-bot"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pipeline/output/songs.json
           git commit -m "chore: auto-update songs.json from raw file list"
-          git push origin HEAD:master
+          git push --force-with-lease origin "HEAD:$BRANCH"
 
-      - name: Upload Pages artifact
-        if: steps.changes.outputs.changed == 'true'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./dist
+          PR_NUMBER=$(gh pr list --base master --head "$BRANCH" --state open --json number --jq '.[0].number')
 
-      - name: Deploy to GitHub Pages
-        if: steps.changes.outputs.changed == 'true'
-        id: deployment
-        uses: actions/deploy-pages@v4
+          if [ -z "$PR_NUMBER" ]; then
+            gh pr create \
+              --base master \
+              --head "$BRANCH" \
+              --title "chore: update generated song list" \
+              --body "Automated update from the latest karaoke laptop scan."
+            PR_NUMBER=$(gh pr list --base master --head "$BRANCH" --state open --json number --jq '.[0].number')
+          fi
+
+          if [ "$(gh pr view "$PR_NUMBER" --json autoMergeRequest --jq '.autoMergeRequest != null')" != "true" ]; then
+            gh pr merge "$PR_NUMBER" --auto --squash --delete-branch
+          fi
 
       - name: Find pipeline report
         if: always()

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Double-click `aktualizuj-liste.bat`. The script:
 - scans all folders from `folderPaths`
 - collects files matching the configured extensions
 - uploads the file list to GitHub as `pipeline/input/raw-filelist.json`
-- GitHub Actions automatically processes the list, commits `pipeline/output/songs.json`, and deploys the site
+- GitHub Actions processes the list, opens an auto-merge PR for `pipeline/output/songs.json`, and deploys the site after merge
 
 Logs are saved to `scan-log.txt` in the same folder as the script.
 
@@ -121,13 +121,15 @@ Pipeline steps:
 - applies manual overrides from `data/manual-overrides.json`
 - deduplicates (same artist + title = one entry)
 - safety check: aborts if the new list is less than half the size of the previous one
-- commits `songs.json` to `master` and deploys the site
+- opens or updates an auto-merge PR with `songs.json`
+
+Requires repository secret `SONG_UPDATE_TOKEN` with **Contents: Read and write** and **Pull requests: Read and write** for `zyleta-karaoke`. This token creates the generated-song PR so required checks can run and `master` still rejects direct pushes.
 
 The MusicBrainz cache is persisted between runs (via `actions/cache@v4`), so subsequent updates only process new songs.
 
 ### 2. Build and Deploy (`deploy.yml`)
 
-Standard CI/CD pipeline — triggered automatically on every push to `master`.
+Standard CI/CD pipeline — triggered automatically on every push to `master`, except raw laptop scans that only touch `pipeline/input/raw-filelist.json`.
 
 Pipeline: lint → test → build → deploy to GitHub Pages.
 

--- a/pipeline/__tests__/process-filelist.test.ts
+++ b/pipeline/__tests__/process-filelist.test.ts
@@ -32,8 +32,14 @@ describe('karaoke laptop sync', () => {
     const deployWorkflow = fs.readFileSync(path.join(root, '.github/workflows/deploy.yml'), 'utf-8');
 
     expect(regularUpdate).not.toContain('actions/workflows/update-songs.yml/dispatches');
-    expect(processWorkflow).toContain('uses: actions/deploy-pages@v4');
+    expect(processWorkflow).toContain('SONG_UPDATE_TOKEN');
+    expect(processWorkflow).toContain('gh pr create');
+    expect(processWorkflow).toContain('gh pr merge');
+    expect(processWorkflow).toContain('--auto');
+    expect(processWorkflow).not.toContain('git push origin HEAD:master');
+    expect(processWorkflow).not.toContain('uses: actions/deploy-pages@v4');
     expect(deployWorkflow).toContain('pipeline/input/raw-filelist.json');
+    expect(deployWorkflow).toContain('uses: actions/deploy-pages@v4');
   });
 
   it('drops songs removed from the latest laptop scan', () => {


### PR DESCRIPTION
## What changed
- Process Song List no longer pushes generated `songs.json` directly to `master`.
- It pushes `pipeline/output/songs.json` to `automation/update-songs`, opens or updates a PR, then enables auto-merge.
- Build and Deploy stays responsible for Pages deploy after that PR lands on `master`.
- Added a regression check so the workflow cannot silently return to direct `master` pushes.

## Setup
- Added `SONG_UPDATE_TOKEN` as a repository secret using the current GitHub.com token from this machine, per request.

## Checks
- `npm run test -- pipeline/__tests__/process-filelist.test.ts`
- workflow YAML parsed locally