### PR TITLE
Fix generated song PR token push

### DIFF
--- a/.github/workflows/update-songs.yml
+++ b/.github/workflows/update-songs.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate raw file list
         run: |

--- a/pipeline/__tests__/process-filelist.test.ts
+++ b/pipeline/__tests__/process-filelist.test.ts
@@ -33,6 +33,7 @@ describe('karaoke laptop sync', () => {
 
     expect(regularUpdate).not.toContain('actions/workflows/update-songs.yml/dispatches');
     expect(processWorkflow).toContain('SONG_UPDATE_TOKEN');
+    expect(processWorkflow).toContain('persist-credentials: false');
     expect(processWorkflow).toContain('gh pr create');
     expect(processWorkflow).toContain('gh pr merge');
     expect(processWorkflow).toContain('--auto');


### PR DESCRIPTION
## What changed
- `actions/checkout` now uses `persist-credentials: false` in `update-songs.yml`.
- This prevents the default `github-actions[bot]` credential from overriding `SONG_UPDATE_TOKEN` during `git push`.
- Added a regression assertion for this workflow setting.

## Checks
- `npm run test -- pipeline/__tests__/process-filelist.test.ts`
- workflow YAML parsed locally