### PR TITLE
Fix generated songs PR merge automation

### DIFF
--- a/.github/workflows/update-songs.yml
+++ b/.github/workflows/update-songs.yml
@@ -186,9 +186,34 @@ jobs:
             PR_NUMBER=$(gh pr list --base master --head "$BRANCH" --state open --json number --jq '.[0].number')
           fi
 
-          if [ "$(gh pr view "$PR_NUMBER" --json autoMergeRequest --jq '.autoMergeRequest != null')" != "true" ]; then
-            gh pr merge "$PR_NUMBER" --auto --squash --delete-branch
-          fi
+          for attempt in {1..60}; do
+            PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
+            MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus --jq '.mergeStateStatus')
+            CHECKS_JSON=$(gh pr checks "$PR_NUMBER" --json name,bucket,state 2>/dev/null || echo '[]')
+            CHECK_COUNT=$(jq 'length' <<<"$CHECKS_JSON")
+            PENDING_CHECKS=$(jq '[.[] | select(.bucket == "pending")] | length' <<<"$CHECKS_JSON")
+            BLOCKING_CHECKS=$(jq '[.[] | select(.bucket != "pass" and .bucket != "skipping" and .bucket != "pending")] | length' <<<"$CHECKS_JSON")
+
+            if [ "$PR_STATE" = "MERGED" ]; then
+              exit 0
+            fi
+
+            if [ "$PR_STATE" != "OPEN" ]; then
+              echo "::error::Generated songs PR #$PR_NUMBER is $PR_STATE"
+              exit 1
+            fi
+
+            if [ "$CHECK_COUNT" -gt 0 ] && [ "$PENDING_CHECKS" -eq 0 ] && [ "$BLOCKING_CHECKS" -eq 0 ] && [ "$MERGE_STATE" = "CLEAN" ]; then
+              gh pr merge "$PR_NUMBER" --squash --delete-branch
+              exit 0
+            fi
+
+            echo "Waiting for PR #$PR_NUMBER checks (attempt $attempt/60): merge=$MERGE_STATE pending=$PENDING_CHECKS blocking=$BLOCKING_CHECKS"
+            sleep 30
+          done
+
+          echo "::error::Timed out waiting for generated songs PR #$PR_NUMBER to become mergeable"
+          exit 1
 
       - name: Find pipeline report
         if: always()

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Double-click `aktualizuj-liste.bat`. The script:
 - scans all folders from `folderPaths`
 - collects files matching the configured extensions
 - uploads the file list to GitHub as `pipeline/input/raw-filelist.json`
-- GitHub Actions processes the list, opens an auto-merge PR for `pipeline/output/songs.json`, and deploys the site after merge
+- GitHub Actions processes the list, opens a PR for `pipeline/output/songs.json`, merges it after checks pass, and deploys the site
 
 Logs are saved to `scan-log.txt` in the same folder as the script.
 
@@ -121,7 +121,7 @@ Pipeline steps:
 - applies manual overrides from `data/manual-overrides.json`
 - deduplicates (same artist + title = one entry)
 - safety check: aborts if the new list is less than half the size of the previous one
-- opens or updates an auto-merge PR with `songs.json`
+- opens or updates a PR with `songs.json`, waits for checks, then merges it
 
 Requires repository secret `SONG_UPDATE_TOKEN` with **Contents: Read and write** and **Pull requests: Read and write** for `zyleta-karaoke`. This token creates the generated-song PR so required checks can run and `master` still rejects direct pushes.
 

--- a/pipeline/__tests__/process-filelist.test.ts
+++ b/pipeline/__tests__/process-filelist.test.ts
@@ -36,7 +36,10 @@ describe('karaoke laptop sync', () => {
     expect(processWorkflow).toContain('persist-credentials: false');
     expect(processWorkflow).toContain('gh pr create');
     expect(processWorkflow).toContain('gh pr merge');
-    expect(processWorkflow).toContain('--auto');
+    expect(processWorkflow).toContain('gh pr checks');
+    expect(processWorkflow).toContain('mergeStateStatus');
+    expect(processWorkflow).toContain('Waiting for PR #$PR_NUMBER checks');
+    expect(processWorkflow).not.toContain('--auto');
     expect(processWorkflow).not.toContain('git push origin HEAD:master');
     expect(processWorkflow).not.toContain('uses: actions/deploy-pages@v4');
     expect(deployWorkflow).toContain('pipeline/input/raw-filelist.json');


### PR DESCRIPTION
## What changed
- `Process Song List` no longer relies on GitHub auto-merge firing later.
- After creating the generated `songs.json` PR, it polls PR checks and `mergeStateStatus`.
- Once checks are done and the PR is `CLEAN`, the workflow merges the PR itself with `SONG_UPDATE_TOKEN`.
- If checks fail or the PR never becomes mergeable, the workflow fails loudly instead of leaving a silent open PR.

## Checks
- `npm run test -- pipeline/__tests__/process-filelist.test.ts`
- workflow YAML parsed locally