### PR TITLE
test: create generated songs drift

### DIFF
--- a/pipeline/output/songs.json
+++ b/pipeline/output/songs.json
@@ -1,14 +1,5 @@
 [
   {
-    "id": "10cc-i-m-not-in-love",
-    "artist": "10cc",
-    "title": "I'm Not in Love",
-    "country": "EN",
-    "language": "EN",
-    "year": 1975,
-    "sourceFilename": "Aaron Bayler - I'm Not In Love.cdg"
-  },
-  {
     "id": "10cc-dreadlock-holiday",
     "artist": "10cc",
     "title": "Dreadlock Holiday",


### PR DESCRIPTION
Temporary smoke-test setup: removes one generated song so Process Song List can prove it restores and merges the generated PR automatically.