### PR TITLE
Fix desktop wishlist button placement

### DIFF
--- a/src/components/Wishlist/WishlistFAB.tsx
+++ b/src/components/Wishlist/WishlistFAB.tsx
@@ -20,6 +20,10 @@ export function WishlistFAB({ count, position, onOpen, onPositionChange }: Wishl
   const startPositionRef = useRef({ x: 0, y: 0 });
   const currentPositionRef = useRef({ x: position.x, y: position.y });
 
+  useEffect(() => {
+    currentPositionRef.current = { x: position.x, y: position.y };
+  }, [position.x, position.y]);
+
   const clamp = useCallback((x: number, y: number) => {
     const maxX = window.innerWidth - FAB_W;
     const maxY = window.innerHeight - FAB_H;

--- a/src/hooks/__tests__/useWishlist.test.tsx
+++ b/src/hooks/__tests__/useWishlist.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWishlist } from '../useWishlist';
+
+function mockLocalStorage() {
+  const store = new Map<string, string>();
+  const storage = {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => store.set(key, value)),
+    removeItem: vi.fn((key: string) => store.delete(key)),
+    clear: vi.fn(() => store.clear()),
+  };
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage,
+  });
+}
+
+function TestHarness() {
+  const { wishlistedIds, toggleSong, fabPosition } = useWishlist();
+
+  return (
+    <>
+      <div role="toolbar" />
+      <button type="button" onClick={() => toggleSong('song-1')}>
+        toggle
+      </button>
+      <output data-testid="count">{wishlistedIds.length}</output>
+      <output data-testid="position">
+        {fabPosition.x},{fabPosition.y}
+      </output>
+    </>
+  );
+}
+
+describe('useWishlist', () => {
+  beforeEach(() => {
+    mockLocalStorage();
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1480 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 });
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: HTMLElement,
+    ) {
+      if (this.getAttribute('role') === 'toolbar') {
+        return {
+          left: 260,
+          top: 144,
+          width: 960,
+          height: 54,
+          right: 1220,
+          bottom: 198,
+          x: 260,
+          y: 144,
+          toJSON: () => {},
+        };
+      }
+
+      return {
+        left: 0,
+        top: 0,
+        width: 0,
+        height: 0,
+        right: 0,
+        bottom: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('places the first wishlist button near the desktop toolbar', async () => {
+    render(<TestHarness />);
+
+    fireEvent.click(screen.getByText('toggle'));
+
+    expect(screen.getByTestId('count')).toHaveTextContent('1');
+    await waitFor(() => expect(screen.getByTestId('position')).toHaveTextContent('930,134'));
+  });
+});

--- a/src/hooks/__tests__/useWishlist.test.tsx
+++ b/src/hooks/__tests__/useWishlist.test.tsx
@@ -82,4 +82,16 @@ describe('useWishlist', () => {
     expect(screen.getByTestId('count')).toHaveTextContent('1');
     await waitFor(() => expect(screen.getByTestId('position')).toHaveTextContent('930,134'));
   });
+
+  it('keeps the existing mobile default position', async () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 390 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 844 });
+
+    render(<TestHarness />);
+
+    fireEvent.click(screen.getByText('toggle'));
+
+    expect(screen.getByTestId('count')).toHaveTextContent('1');
+    await waitFor(() => expect(screen.getByTestId('position')).toHaveTextContent('318,772'));
+  });
 });

--- a/src/hooks/useWishlist.ts
+++ b/src/hooks/useWishlist.ts
@@ -1,9 +1,14 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 
 const WISHLIST_KEY = 'zyleta-wishlist';
 const FAB_KEY = 'zyleta-wishlist-fab';
 
-const FAB_SIZE = 56;
+const FAB_WIDTH = 100;
+const FAB_HEIGHT = 54;
+const FAB_GAP = 16;
+const DESKTOP_MIN_WIDTH = 900;
+const TOOLBAR_X_RATIO = 0.75;
+const TOOLBAR_Y_OFFSET = 10;
 
 interface FabPosition {
   x: number;
@@ -21,16 +26,27 @@ interface WishlistActions {
 
 function clampToViewport(x: number, y: number): FabPosition {
   return {
-    x: Math.max(0, Math.min(x, window.innerWidth - FAB_SIZE)),
-    y: Math.max(0, Math.min(y, window.innerHeight - FAB_SIZE)),
+    x: Math.max(0, Math.min(x, window.innerWidth - FAB_WIDTH)),
+    y: Math.max(0, Math.min(y, window.innerHeight - FAB_HEIGHT)),
   };
 }
 
 function getDefaultFabPosition(): FabPosition {
-  return {
-    x: window.innerWidth - FAB_SIZE - 16,
-    y: window.innerHeight - FAB_SIZE - 16,
+  const fallback = {
+    x: window.innerWidth - FAB_WIDTH - FAB_GAP,
+    y: window.innerHeight - FAB_HEIGHT - FAB_GAP,
   };
+
+  if (window.innerWidth < DESKTOP_MIN_WIDTH) return fallback;
+
+  const toolbar = document.querySelector<HTMLElement>('[role="toolbar"]');
+  if (!toolbar) return fallback;
+
+  const rect = toolbar.getBoundingClientRect();
+  return clampToViewport(
+    rect.left + rect.width * TOOLBAR_X_RATIO - FAB_WIDTH / 2,
+    rect.top - TOOLBAR_Y_OFFSET,
+  );
 }
 
 function readWishlist(): string[] {
@@ -68,6 +84,7 @@ function readFabPosition(): FabPosition {
 
 export function useWishlist(): WishlistActions {
   const [wishlistedIds, setWishlistedIds] = useState<string[]>(readWishlist);
+  const hasSavedFabPositionRef = useRef(localStorage.getItem(FAB_KEY) !== null);
   const [fabPosition, setFabPosition] = useState<FabPosition>(readFabPosition);
 
   useEffect(() => {
@@ -75,9 +92,13 @@ export function useWishlist(): WishlistActions {
   }, [wishlistedIds]);
 
   const toggleSong = useCallback((id: string) => {
-    setWishlistedIds((prev) =>
-      prev.includes(id) ? prev.filter((sid) => sid !== id) : [...prev, id],
-    );
+    setWishlistedIds((prev) => {
+      if (prev.includes(id)) return prev.filter((sid) => sid !== id);
+      if (prev.length === 0 && !hasSavedFabPositionRef.current) {
+        setFabPosition(getDefaultFabPosition());
+      }
+      return [...prev, id];
+    });
   }, []);
 
   const removeSong = useCallback((id: string) => {
@@ -91,6 +112,7 @@ export function useWishlist(): WishlistActions {
   const saveFabPosition = useCallback((x: number, y: number) => {
     const clamped = clampToViewport(x, y);
     setFabPosition(clamped);
+    hasSavedFabPositionRef.current = true;
     localStorage.setItem(FAB_KEY, JSON.stringify(clamped));
   }, []);
 

--- a/src/hooks/useWishlist.ts
+++ b/src/hooks/useWishlist.ts
@@ -3,8 +3,8 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 const WISHLIST_KEY = 'zyleta-wishlist';
 const FAB_KEY = 'zyleta-wishlist-fab';
 
+const LEGACY_MOBILE_FAB_SIZE = 56;
 const FAB_WIDTH = 100;
-const FAB_HEIGHT = 54;
 const FAB_GAP = 16;
 const DESKTOP_MIN_WIDTH = 900;
 const TOOLBAR_X_RATIO = 0.75;
@@ -26,15 +26,15 @@ interface WishlistActions {
 
 function clampToViewport(x: number, y: number): FabPosition {
   return {
-    x: Math.max(0, Math.min(x, window.innerWidth - FAB_WIDTH)),
-    y: Math.max(0, Math.min(y, window.innerHeight - FAB_HEIGHT)),
+    x: Math.max(0, Math.min(x, window.innerWidth - LEGACY_MOBILE_FAB_SIZE)),
+    y: Math.max(0, Math.min(y, window.innerHeight - LEGACY_MOBILE_FAB_SIZE)),
   };
 }
 
 function getDefaultFabPosition(): FabPosition {
   const fallback = {
-    x: window.innerWidth - FAB_WIDTH - FAB_GAP,
-    y: window.innerHeight - FAB_HEIGHT - FAB_GAP,
+    x: window.innerWidth - LEGACY_MOBILE_FAB_SIZE - FAB_GAP,
+    y: window.innerHeight - LEGACY_MOBILE_FAB_SIZE - FAB_GAP,
   };
 
   if (window.innerWidth < DESKTOP_MIN_WIDTH) return fallback;


### PR DESCRIPTION
## What changed
- Default wishlist FAB position on desktop now anchors to the sort toolbar: 75% across the toolbar and slightly above it.
- Mobile fallback stays bottom-right.
- Saved dragged positions still win.
- Synced the FAB drag ref when the default position is recalculated.

## Preview
- Local preview at 1480x900: toolbar `x=284 y=219 w=912`, FAB `x=918 y=209 w=100 h=54`.

## Checks
- `npm run test -- src/hooks/__tests__/useWishlist.test.tsx`
- `npm run build`